### PR TITLE
add resources/data_formats/* to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(name='latools',
       package_data={
         'latools': ['latools.cfg',
                     'resources/*',
+                    'resources/data_formats/*',
                     'resources/test_data/*'],
       },
       zip_safe=False)


### PR DESCRIPTION
Hello,

I have worked with Ann and Edward to debug a problem related to missing resources. I believe the data_formats folder must be included in the package data, to alleviate the need to manually duplicate it for each project.